### PR TITLE
🛠️ Fix MCP default exchange adapter

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,13 +15,6 @@
             "refinery": "0x9746de29f1dd31b2c8460d71e92a7aefa34911130e61f274f37776e598c48bec",
             "agentAdapter": "0xf6d54cf6a0619f1fb8e1ded91d4c23e7bb9f498c56735fb0c7669423c766219f",
             "agentFee": "0x151234279af18acc113f70463977058efa2e598b5bfc0c106c75fd638d344c0a"
-        },
-        "dex": {
-            "agent": {
-                "type": "universal",
-                "adapter": "0x0002BeFB46587d460AcEA9B2792c4A4c67B9cADa",
-                "fee": "0x0006d9557Ac9Af4f31962896299ba4FaBDaB9fEE"
-            }
         }
     },
     "1": {


### PR DESCRIPTION
## Summary
- Remove the global wildcard `dex.agent` exchange from `config.json`
- Prevent the MCP `prepare` default `exchangeIndex: 0` from selecting the wildcard universal adapter for every chain
- Let per-chain `dex.agent` entries become the chain-local default exchange adapter

## Context
The hosted MCP was preparing orders with `0x0002BeFB46587d460AcEA9B2792c4A4c67B9cADa` as the exchange adapter across chains instead of the per-chain agent adapters.

## Verification
- `jq empty config.json`
- `npm run sync`
- `forge test` — 201 passed, 0 failed
