### PR TITLE
feat(skill): add Hermes-compatible frontmatter

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spot-advanced-swap-orders
 description: Use for gasless non-custodial EVM market, limit, TWAP, stop-loss, take-profit, delayed-start swaps.
-version: 1.0.0
+version: 2.5.6
 author: Orbs Network
 license: MIT
 metadata:

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: spot-advanced-swap-orders
 description: Use for gasless non-custodial EVM market, limit, TWAP, stop-loss, take-profit, delayed-start swaps.
+version: 1.0.0
+author: Orbs Network
+license: MIT
+metadata:
+  hermes:
+    tags: [DeFi, EVM, swaps, limit-orders, TWAP, stop-loss, Ethereum, Polygon, Base, Arbitrum, Avalanche, BNB, crypto, Web3]
+    category: blockchain
+    related_skills: [evm]
 ---
 
 # Spot Advanced Swap Orders


### PR DESCRIPTION
Adds the missing frontmatter fields required for listing in the Hermes Agent skills registry.

**Changes:** `skill/SKILL.md` frontmatter only — no content changes.

**Added fields:**
```yaml
version: 1.0.0
author: Orbs Network
license: MIT
metadata:
  hermes:
    tags: [DeFi, EVM, swaps, limit-orders, TWAP, stop-loss, Ethereum, Polygon, Base, Arbitrum, Avalanche, BNB, crypto, Web3]
    category: blockchain
    related_skills: [evm]
```

This enables the skill to be submitted to [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) optional-skills registry.